### PR TITLE
Make _initBreakpoints function accessable

### DIFF
--- a/lib/dd.breakpoints.js
+++ b/lib/dd.breakpoints.js
@@ -79,7 +79,7 @@
 		 * @memberof DD.bp
 		 * @private
 		 */
-		_initBreakpoints = (function() {
+		_initBreakpoints = function() {
 			//sort the breakpoints into order of smallest to largest
 			var sortedBreakpoints = _options.breakpoints.sort(function(a, b) {
 				// only sort if the correct objects are present
@@ -109,7 +109,8 @@
 					_maxBreakpoints[sortedBreakpoints[i].name] = parseInt(sortedBreakpoints[i + 1].px - 1, 10);
 				}
 			}
-		}());
+		};
+		_initBreakpoints();
 
 		/**
 		 * Splits string syntax 'xs,m' into separate values 'xs' and 'm'


### PR DESCRIPTION
The _initBreakpoints function could not be called from the options function.
