### PR TITLE
Added ability to use xxl as max

### DIFF
--- a/lib/dd.breakpoints.scss
+++ b/lib/dd.breakpoints.scss
@@ -29,11 +29,12 @@ $bp-s-max: $bp-m-min - 1;
 $bp-m-max: $bp-l-min - 1;
 $bp-l-max: $bp-xl-min - 1;
 $bp-xl-max: $bp-xxl-min - 1;
+$bp-xxl-max: $bp-xxl-min + 1;
 
 // The list of breakpoints (order doesn't matter). If you add another
 // breakpoint be sure to add it here too
 $bp-list-min: xxs $bp-xxs-min, xs $bp-xs-min, s $bp-s-min, m $bp-m-min, l $bp-l-min, xl $bp-xl-min, xxl $bp-xxl-min;
-$bp-list-max: xxs $bp-xxs-max, xs $bp-xs-max, s $bp-s-max, m $bp-m-max, l $bp-l-max, xl $bp-xl-max;
+$bp-list-max: xxs $bp-xxs-max, xs $bp-xs-max, s $bp-s-max, m $bp-m-max, l $bp-l-max, xl $bp-xl-max, xxl $bp-xxl-max;
 
 // Range for the static stylesheet to use. Is used when $IS_RESPONSIVE is equal to false
 // and ignores breakpoints outside of the specified range

--- a/lib/dd.breakpoints.scss
+++ b/lib/dd.breakpoints.scss
@@ -29,7 +29,7 @@ $bp-s-max: $bp-m-min - 1;
 $bp-m-max: $bp-l-min - 1;
 $bp-l-max: $bp-xl-min - 1;
 $bp-xl-max: $bp-xxl-min - 1;
-$bp-xxl-max: $bp-xxl-min + 1;
+$bp-xxl-max: $bp-xxl-min;
 
 // The list of breakpoints (order doesn't matter). If you add another
 // breakpoint be sure to add it here too


### PR DESCRIPTION
When using the xxl breakpoint as the max, such as in the following example: 

```
@include bp(xl, xxl) {
    background:red;
}
```

The output would be something like the following (note the 1emem caused by line 71): 

```
@media only screen and (min-width: 77.75em) and (max-width: 1emem) {
  body {
    background: red; 
  }
}
```

Adding an xxl-max to the max list resolved this issue. 
