### PR TITLE
Added simplified version of MQAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,24 @@ There is also a shortcut function for height based media queries
 DD.bp.isHeight(min /* string || number */, max = 0 /* string || number */);
 ```
 
+#### .at()
+
+Will run a couple of functions depending on if the breakpoint is matched or not. This uses `enquire.js` so make sure to include the [library](http://wicky.nillia.ms/enquire.js/) if you need it.
+
+```javascript
+DD.bp.at(bp /* string */, attach = function() {}, property = function() {});
+
+// examples
+DD.bp.at('m,l', doWhenAttached, doWhenNotAttached);
+DD.bp.at('0,l', function(init) {
+    console.log('fire when the screen is between 0 and l');
+    console.log('if init === true, you can change the required code to stop inital screen flicker', init);
+}, function(init) {
+    console.log('fire when the screen is NOT between 0 and l');
+    console.log('if init === true, you can change the required code to stop inital screen flicker', init);
+});
+```
+
 #### .options()
 
 You can customise the JavaScript library by using the `options()` method.
@@ -233,6 +251,10 @@ DD.bp.options({
 Make sure to ensure that the values used here match the values used in the SCSS.
 
 ## Change log
+
+`1.1.0` - October 2015
+
+* Added code for Media Query Attach/Detach (taken from the Deloitte Digital FED framework)
 
 `1.0.3` & `1.0.4` - September 2015
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "DDBreakpoints",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "homepage": "https://github.com/DeloitteDigital/DDBreakpoints",
   "authors": [ "Deloitte Digital Australia" ],
   "description": "Breakpoints SCSS Mixin and JavaScript tool, used to accelerate the development process of responsive pages.",

--- a/lib/dd.breakpoints.js
+++ b/lib/dd.breakpoints.js
@@ -12,8 +12,8 @@
 	 *
 	 * @namespace bp
 	 * @memberof DD
-	 * @version 1.0.0
-	 * @copyright 2012-2014 Deloitte Digital Australia - http://www.deloittedigital.com/au
+	 * @version 1.1.0
+	 * @copyright 2012-2015 Deloitte Digital Australia - http://www.deloittedigital.com/au
 	 * @author Deloitte Digital Australia deloittedigital@deloitte.com.au
 	 * @license BSD 3-Clause (http://opensource.org/licenses/BSD-3-Clause)
 	 */
@@ -70,6 +70,7 @@
 			getHeight,
 			is,
 			isHeight,
+			at,
 			options;
 
 		/**
@@ -464,6 +465,65 @@
 		};
 
 		/**
+		 * Run specific functionality at a certain breakpoint and 
+		 * use enquire.js to trigger the attach or detach functions
+		 * as expected when the breakpoint is matched/unmatched
+		 *
+		 * @memberof DD.bp
+		 * @example
+		 * // returns true if the page is between 0 and 300px high
+		 * DD.bp.at('m,l', doWhenAttached, doWhenNotAttached);
+		 * DD.bp.at('0,l', function(init) {
+		 *     console.log('fire when the screen is between 0 and l');
+		 *     console.log('if init === true, you can change the required code to stop inital screen flicker', init);
+		 * }, function(init) {
+		 *     console.log('fire when the screen is NOT between 0 and l');
+		 *     console.log('if init === true, you can change the required code to stop inital screen flicker', init);
+		 * });
+		 *
+		 * @param  {String} bp Breakpoint name as a string
+		 * @param  {Function} attach Function to call on match of the included breakpoint
+		 * @param  {Function} detach Function to call on unmatch of the included breakpoint
+		 * @return {Boolean}
+		 */
+		at = function(bp, attach, detach) {
+			if (!enquire) {
+				console.warn('DD.bp: enquire.js is required to use .at(bp, attach, detach)');
+				return;
+			}
+
+			var onAttach,
+				onDetach;
+
+			onAttach = function(init) {
+				init = (typeof (init) === 'boolean') ? init : false;
+
+				if (typeof (attach) === 'function') {
+					attach(init);
+				}
+			};
+
+			onDetach = function(init) {
+				init = (typeof (init) === 'boolean') ? init : false;
+
+				if (typeof (detach) === 'function') {
+					detach(init);
+				}
+			};
+
+			if (is(bp)) {
+				onAttach(true);
+			} else {
+				onDetach(true);
+			}
+
+			enquire.register(get(bp), {
+				match: onAttach,
+				unmatch: onDetach
+			});
+		};
+
+		/**
 		 * Valid options for the Breakpoints array
 		 *
 		 * @typedef  {Object} DD.bp.BreakpointOptions
@@ -539,6 +599,7 @@
 			getHeight: getHeight,
 			is: is,
 			isHeight: isHeight,
+			at: at,
 			options: options
 		};
 	}());

--- a/lib/dd.breakpoints.scss
+++ b/lib/dd.breakpoints.scss
@@ -1,8 +1,8 @@
 /**
  * Breakpoints for JavaScript. Works with the Deloitte Digital SCSS @bp mixin
  *
- * @version 1.0.0
- * @copyright 2012-2014 Deloitte Digital Australia - http://www.deloittedigital.com/au
+ * @version 1.1.0
+ * @copyright 2012-2015 Deloitte Digital Australia - http://www.deloittedigital.com/au
  * @author Deloitte Digital Australia deloittedigital@deloitte.com.au
  * @license BSD 3-Clause (http://opensource.org/licenses/BSD-3-Clause)
  */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ddbreakpoints",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Breakpoints SCSS Mixin and JavaScript tool, used to accelerate the development process of responsive pages.",
   "main": "lib/dd.breakpoints.js",
   "directories": {


### PR DESCRIPTION
I've added a new function called `.at()` which is used in a similar way to our DD FED framework's Media Query Attach/Detach (MQAD) code.

This is a lot simpler than the MQAD code because that code allows for a choice of attaching or detaching to a breakpoint. We don't actually need to have that additional complexity by only allowing the user to attach to a breakpoint and assuming that anything that doesn't match the breakpoint fires the detach function instead.

This is a much simpler approach than we currently use and will help streamline some of our internal functions.

I do a check for enquire.js and issue a warning if the user doesn't have it included so you can still use the library without needing enquire if you don't want it. 
