### PR TITLE
Migrate to gh apac

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Copyright (C) 2015, Deloitte Digital. All rights reserved.
 
-DDBreakpoints can be downloaded from: https://github.com/DeloitteDigital/DDBreakpoints
+DDBreakpoints can be downloaded from: https://github.com/DeloitteDigitalAPAC/DDBreakpoints
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -311,31 +311,4 @@ Pioneered in Australia, Deloitte Digital is committed to helping clients unlock 
 [http://www.deloittedigital.com/au](http://www.deloittedigital.com/au)
 
 ## LICENSE (BSD-3-Clause)
-Copyright (C) 2015, Deloitte Digital. All rights reserved.
-
-DDBreakpoints can be downloaded from: https://github.com/DeloitteDigital/DDBreakpoints
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this
-list of conditions and the following disclaimer.
-
-* Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-
-* Neither the name of the copyright holder nor the names of its contributors 
-may be used to endorse or promote products derived from this software without 
-specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+[View License](LICENSE)

--- a/README.md
+++ b/README.md
@@ -234,6 +234,10 @@ Make sure to ensure that the values used here match the values used in the SCSS.
 
 ## Change log
 
+`1.0.5` - July 2016
+
+* Migrate GitHub organisation to: DeloitteDigitalAPAC.
+
 `1.0.3` & `1.0.4` - September 2015
 
 * Publish on npm.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "DDBreakpoints",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "homepage": "https://github.com/DeloitteDigitalAPAC/DDBreakpoints",
   "authors": [ "Deloitte Digital Australia" ],
   "description": "Breakpoints SCSS Mixin and JavaScript tool, used to accelerate the development process of responsive pages.",

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "DDBreakpoints",
   "version": "1.0.4",
-  "homepage": "https://github.com/DeloitteDigital/DDBreakpoints",
+  "homepage": "https://github.com/DeloitteDigitalAPAC/DDBreakpoints",
   "authors": [ "Deloitte Digital Australia" ],
   "description": "Breakpoints SCSS Mixin and JavaScript tool, used to accelerate the development process of responsive pages.",
   "main": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ddbreakpoints",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Breakpoints SCSS Mixin and JavaScript tool, used to accelerate the development process of responsive pages.",
   "main": "lib/dd.breakpoints.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/DeloitteDigital/DDBreakpoints.git"
+    "url": "git+https://github.com/DeloitteDigitalAPAC/DDBreakpoints.git"
   },
   "keywords": [
     "deloitte",
@@ -27,7 +27,7 @@
   "author": "Deloitte Digital Australia (http://deloittedigital.com.au)",
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/DeloitteDigital/DDBreakpoints/issues"
+    "url": "https://github.com/DeloitteDigitalAPAC/DDBreakpoints/issues"
   },
-  "homepage": "https://github.com/DeloitteDigital/DDBreakpoints#readme"
+  "homepage": "https://github.com/DeloitteDigitalAPAC/DDBreakpoints#readme"
 }


### PR DESCRIPTION
We've transferred GitHub ownership of this repo from DeloitteDigital to DeloitteDigitalAPAC.

This PR updates the repo as necessary, setting the ground for an NPM and Bower update as well.
