### PR TITLE
Extended defaults to other size variables

### DIFF
--- a/lib/dd.breakpoints.scss
+++ b/lib/dd.breakpoints.scss
@@ -23,17 +23,17 @@ $bp-xxl-min: 1410 !default;
 
 
 // Get the max of the breakpoint by taking 1px from the min of the next breakpoint
-$bp-xxs-max: $bp-xs-min - 1;
-$bp-xs-max: $bp-s-min - 1;
-$bp-s-max: $bp-m-min - 1;
-$bp-m-max: $bp-l-min - 1;
-$bp-l-max: $bp-xl-min - 1;
-$bp-xl-max: $bp-xxl-min - 1;
+$bp-xxs-max: $bp-xs-min - 1 !default;
+$bp-xs-max: $bp-s-min - 1 !default;
+$bp-s-max: $bp-m-min - 1 !default;
+$bp-m-max: $bp-l-min - 1 !default;
+$bp-l-max: $bp-xl-min - 1 !default;
+$bp-xl-max: $bp-xxl-min - 1 !default;
 
 // The list of breakpoints (order doesn't matter). If you add another
 // breakpoint be sure to add it here too
-$bp-list-min: xxs $bp-xxs-min, xs $bp-xs-min, s $bp-s-min, m $bp-m-min, l $bp-l-min, xl $bp-xl-min, xxl $bp-xxl-min;
-$bp-list-max: xxs $bp-xxs-max, xs $bp-xs-max, s $bp-s-max, m $bp-m-max, l $bp-l-max, xl $bp-xl-max;
+$bp-list-min: xxs $bp-xxs-min, xs $bp-xs-min, s $bp-s-min, m $bp-m-min, l $bp-l-min, xl $bp-xl-min, xxl $bp-xxl-min !default;
+$bp-list-max: xxs $bp-xxs-max, xs $bp-xs-max, s $bp-s-max, m $bp-m-max, l $bp-l-max, xl $bp-xl-max !default;
 
 // Range for the static stylesheet to use. Is used when $IS_RESPONSIVE is equal to false
 // and ignores breakpoints outside of the specified range


### PR DESCRIPTION
[SCSS] Found an issue where setting the breakpoints size adjustments for max and list variables before you include dd.breakpoints will ignore the updated values.